### PR TITLE
feat: ability to exclude columns from audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ use Illuminate\Database\Eloquent\Model;
 class YourModel extends Model
 {
     use AuditableModel;
+    
+    /* An array of columns that shouldn't be audited. */
+     protected array $excludedFromAuditing = [
+     'created_at',
+     'updated_at',
+     // 
+    ];
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -114,21 +114,24 @@ class MyCustomEvent implements IsAuditableEvent
 
 If you have a model that you'd like to be audited on change, you can use the `AuditableModel` trait.
 By default, this will record all creations, updates and deletions for this model to the audit log.
-This uses Laravel model observers to listen for changes.
+This uses Laravel model observers to listen for changes. By default, the `created_at` and `updated_at` columns
+are excluded from auditing.
 
 ```php
-use Motomedialab\SimpleLaravelAudit\Traits\AuditableModel;
 use Illuminate\Database\Eloquent\Model;
+use Motomedialab\SimpleLaravelAudit\Traits\AuditableModel;
 
 class YourModel extends Model
 {
     use AuditableModel;
     
-    /* An array of columns that shouldn't be audited. */
-     protected array $excludedFromAuditing = [
-     'created_at',
-     'updated_at',
-     // 
+    /**
+    * An array of columns that shouldn't be audited.
+    * @var array|string[] 
+    */
+    protected array $excludedFromAuditing = [
+        'created_at',
+        'updated_at',
     ];
 }
 ```

--- a/src/Observers/AuditableModelObserver.php
+++ b/src/Observers/AuditableModelObserver.php
@@ -56,7 +56,11 @@ class AuditableModelObserver
         }
 
         $excludedColumns = $model->getExcludedFromAuditing();
+
+        if ($excludedColumns === []) {
+            return $attributes;
+        }
+
         return array_diff_key($attributes, array_flip($excludedColumns));
     }
-
 }

--- a/src/Observers/AuditableModelObserver.php
+++ b/src/Observers/AuditableModelObserver.php
@@ -9,15 +9,22 @@ class AuditableModelObserver
 {
     public function created(Model $model): void
     {
-        $this->auditMessage('Created', $model, $model->getAttributes());
+        $attributes = $this->filterExcludedColumns($model, $model->getAttributes());
+        $this->auditMessage('Created', $model, $attributes);
     }
 
     public function updated(Model $model): void
     {
-        $new = $model->getChanges();
-        $old = array_filter($model->getOriginal(), fn ($key) => array_key_exists($key, $new), ARRAY_FILTER_USE_KEY);
+        $new = $this->filterExcludedColumns($model, $model->getChanges());
+        $old = array_filter(
+            $this->filterExcludedColumns($model, $model->getOriginal()),
+            fn ($key) => array_key_exists($key, $new),
+            ARRAY_FILTER_USE_KEY
+        );
 
-        $this->auditMessage('Updated', $model, compact('old', 'new'));
+        if (!empty($new)) {
+            $this->auditMessage('Updated', $model, compact('old', 'new'));
+        }
     }
 
     public function deleted(Model $model): void
@@ -40,6 +47,16 @@ class AuditableModelObserver
             'class' => get_class($model),
             'id' => $model->getKey(),
         ]);
+    }
+
+    protected function filterExcludedColumns(Model $model, array $attributes): array
+    {
+        if (!method_exists($model, 'getExcludedFromAuditing')) {
+            return $attributes;
+        }
+
+        $excludedColumns = $model->getExcludedFromAuditing();
+        return array_diff_key($attributes, array_flip($excludedColumns));
     }
 
 }

--- a/src/Traits/AuditableModel.php
+++ b/src/Traits/AuditableModel.php
@@ -15,4 +15,9 @@ trait AuditableModel
 
         static::observe(config('simple-auditor.observer', AuditableModelObserver::class));
     }
+
+    public function getExcludedFromAuditing(): array
+    {
+        return $this->excludedFromAuditing ?? [];
+    }
 }

--- a/src/Traits/AuditableModel.php
+++ b/src/Traits/AuditableModel.php
@@ -18,6 +18,9 @@ trait AuditableModel
 
     public function getExcludedFromAuditing(): array
     {
-        return $this->excludedFromAuditing ?? [];
+        return $this->excludedFromAuditing ?? [
+            'created_at',
+            'updated_at',
+        ];
     }
 }

--- a/tests/Feature/ModelObserverTest.php
+++ b/tests/Feature/ModelObserverTest.php
@@ -96,11 +96,37 @@ it('does not create audit log when only excluded columns are updated', function 
     $model = Model::withoutEvents(fn () => TestModel::create([
         'name' => 'Test Model',
         'email_address' => 'test@example.com',
+        'phone_number' => '1234567890'
     ]));
 
     $model->update([
         'email_address' => 'updated@example.com',
+        'phone_number' => '0987654321'
     ]);
 
     expect(AuditLog::count())->toBe(0);
+});
+
+it('excludes multiple defined columns from auditing on update', function () {
+    $model = Model::withoutEvents(fn () => TestModel::create([
+        'name' => 'Test Model',
+        'email_address' => 'test@example.com',
+        'phone_number' => '1234567890'
+    ]));
+
+    $model->update([
+        'name' => 'Updated Model',
+        'email_address' => 'updated@example.com',
+        'phone_number' => '0987654321'
+    ]);
+
+    expect(AuditLog::first())
+        ->toBeInstanceOf(AuditLog::class)
+        ->message->toBe('TestModel Updated')
+        ->context->old->toHaveKey('name')
+        ->context->old->not->toHaveKey('email_address')
+        ->context->old->not->toHaveKey('phone_number')
+        ->context->new->toHaveKey('name')
+        ->context->new->not->toHaveKey('email_address')
+        ->context->new->not->toHaveKey('phone_number');
 });

--- a/tests/Stubs/TestModel.php
+++ b/tests/Stubs/TestModel.php
@@ -10,4 +10,8 @@ class TestModel extends Model
     use AuditableModel;
 
     protected $guarded = [];
+
+    protected array $excludedFromAuditing = [
+        'email_address'
+    ];
 }

--- a/tests/Stubs/TestModel.php
+++ b/tests/Stubs/TestModel.php
@@ -12,6 +12,7 @@ class TestModel extends Model
     protected $guarded = [];
 
     protected array $excludedFromAuditing = [
-        'email_address'
+        'email_address',
+        'phone_number',
     ];
 }

--- a/tests/migrations/2024_08_16_083011_create_test_models_table.php
+++ b/tests/migrations/2024_08_16_083011_create_test_models_table.php
@@ -14,6 +14,7 @@ return new class () extends Migration {
             $table->id();
 
             $table->string('name');
+            $table->string('email_address')->nullable();
 
             $table->timestamps();
             $table->softDeletes();

--- a/tests/migrations/2024_08_16_083011_create_test_models_table.php
+++ b/tests/migrations/2024_08_16_083011_create_test_models_table.php
@@ -15,6 +15,7 @@ return new class () extends Migration {
 
             $table->string('name');
             $table->string('email_address')->nullable();
+            $table->string('phone_number')->nullable();
 
             $table->timestamps();
             $table->softDeletes();


### PR DESCRIPTION
This PR adds the ability to exclude columns from being tracked when using the `AuditableModel` trait.

To exclude a column from being tracked, you define an array in the Model. i.e.
```php
use Motomedialab\SimpleLaravelAudit\Traits\AuditableModel;
use Illuminate\Database\Eloquent\Model;

class User extends Model
{
    use AuditableModel;
    
     protected array $excludedFromAuditing = [
     'last_login_at',
    ];
}
```

I did run phpstan, pint and the entire test suite before commiting, but it's probably a good idea to have some github actions on-the-go too (for PRs)

Please let me know if you need any changes or refinement.