### PR TITLE
Added support for MySQL 8

### DIFF
--- a/database/migrations/2024_08_15_145905_create_audit_logs_table.php
+++ b/database/migrations/2024_08_15_145905_create_audit_logs_table.php
@@ -14,7 +14,7 @@ return new class () extends Migration {
             $table->id();
 
             $table->string('message');
-            $table->json('context')->default('[]');
+            $table->longText('context');
 
             $table->unsignedBigInteger('user_id')->nullable()->default(null);
             $table->string('ip_address', 45)->nullable()->default(null);

--- a/src/Models/AuditLog.php
+++ b/src/Models/AuditLog.php
@@ -10,6 +10,9 @@ class AuditLog extends Model
 
     protected $guarded = [];
 
+    protected $attributes = [
+        'context' => '[]'
+    ];
     protected $casts = [
         'context' => 'array'
     ];


### PR DESCRIPTION
Refactored context column to longText with no default

This provides support for MySQL (previously would have thrown an error)

New default has been defined via the `attributes` property on the `AuditLog` model