### PR TITLE
Context data ordering & whitespace consistency formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Out of the box there isn't any requirement to configure the package. It will wor
 
 However, if you'd like to customise any options, such as the table name or classes that are utilised, you can publish the config file
 and change any of the options. It's designed to be flexible allowing you to change IP address resolution, user ID resolution,
-table name and more.
+context data order, table name and more.
 
 ```
 php artisan vendor:publish --tag=simple-auditor

--- a/config/simple-auditor.php
+++ b/config/simple-auditor.php
@@ -93,4 +93,17 @@ return [
     |
     */
     'user_id_fetcher' => Motomedialab\SimpleLaravelAudit\Actions\FetchUserId::class,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Context Sort Order
+    |--------------------------------------------------------------------------
+    |
+    | Optionally define the sort order of the context data inside the table.
+    | - null: Default order based off the lifecycle hook, for example when Updating it would be ['old', 'new', 'class', 'id']
+    | - 'desc' or 'reverse': Fully reverse the default order
+    | - ['key1', 'key2', 'key3', 'key4']: Define a specific order by key, such as ['id', 'class', 'old', 'new']
+    |
+    */
+    'context_sort_order' => null,
 ];

--- a/src/Observers/AuditableModelObserver.php
+++ b/src/Observers/AuditableModelObserver.php
@@ -52,7 +52,7 @@ class AuditableModelObserver
 
         $sortedContext = match (true) {
             // fully reverse the data if specified
-            in_array($contextSortOrder, ['desc', 'reverse']) => array_reverse($contextData),
+            is_string($contextSortOrder) && in_array($contextSortOrder, ['desc', 'reverse']) => array_reverse($contextData),
 
             // attempt to sort using a supplied custom order
             is_array($contextSortOrder) => collect($contextData)
@@ -62,7 +62,7 @@ class AuditableModelObserver
                 })
                 ->toArray(),
 
-            // otherwise, use default
+            // fallback to default
             default => $contextData,
         };
 

--- a/src/Observers/AuditableModelObserver.php
+++ b/src/Observers/AuditableModelObserver.php
@@ -58,7 +58,7 @@ class AuditableModelObserver
             is_array($contextSortOrder) => collect($contextData)
                 ->sortBy(function ($item, $key) use ($contextSortOrder) {
                     $index = array_search($key, $contextSortOrder);
-                    return $index === false ? 999 : $index;
+                    return $index === false ? count($contextSortOrder) : $index;
                 })
                 ->toArray(),
 

--- a/src/Observers/AuditableModelObserver.php
+++ b/src/Observers/AuditableModelObserver.php
@@ -42,11 +42,31 @@ class AuditableModelObserver
 
     protected function auditMessage(string $action, Model $model, array $context = []): void
     {
-        AuditFacade::record(class_basename($model) . ' ' . $action, [
+        $contextData = [
             ...$context,
             'class' => get_class($model),
             'id' => $model->getKey(),
-        ]);
+        ];
+
+        $contextSortOrder = config('simple-auditor.context_sort_order');
+
+        $sortedContext = match (true) {
+            // fully reverse the data if specified
+            in_array($contextSortOrder, ['desc', 'reverse']) => array_reverse($contextData),
+
+            // attempt to sort using a supplied custom order
+            is_array($contextSortOrder) => collect($contextData)
+                ->sortBy(function ($item, $key) use ($contextSortOrder) {
+                    $index = array_search($key, $contextSortOrder);
+                    return $index === false ? 999 : $index;
+                })
+                ->toArray(),
+
+            // otherwise, use default
+            default => $contextData,
+        };
+
+        AuditFacade::record(class_basename($model) . ' ' . $action, $sortedContext);
     }
 
     protected function filterExcludedColumns(Model $model, array $attributes): array

--- a/src/Providers/SimpleAuditServiceProvider.php
+++ b/src/Providers/SimpleAuditServiceProvider.php
@@ -66,5 +66,4 @@ class SimpleAuditServiceProvider extends ServiceProvider
 
         return new FetchIpAddress();
     }
-
 }

--- a/src/Traits/AuditableModel.php
+++ b/src/Traits/AuditableModel.php
@@ -12,7 +12,6 @@ trait AuditableModel
 {
     public static function bootAuditableModel(): void
     {
-
         static::observe(config('simple-auditor.observer', AuditableModelObserver::class));
     }
 

--- a/tests/Feature/AuditableEvents.php
+++ b/tests/Feature/AuditableEvents.php
@@ -4,12 +4,10 @@ use Motomedialab\SimpleLaravelAudit\Models\AuditLog;
 use Motomedialab\SimpleLaravelAudit\Tests\Stubs\TestEvent;
 
 it('listens for an auditable event', function () {
-
     // dispatch our test event
     event(new TestEvent());
 
     expect(AuditLog::first())
         ->toBeInstanceOf(AuditLog::class)
         ->message->toBe('Event: TestEvent');
-
 });

--- a/tests/Feature/AuditorTest.php
+++ b/tests/Feature/AuditorTest.php
@@ -16,7 +16,6 @@ it('can load an auditor instance', function () {
 });
 
 it('can create an audit log via the facade', function () {
-
     $this->mock(FetchesIpAddress::class)
         ->shouldReceive('__invoke')->once()->andReturn('testIpAddress');
 

--- a/tests/Feature/ModelObserverTest.php
+++ b/tests/Feature/ModelObserverTest.php
@@ -132,7 +132,7 @@ it('excludes multiple defined columns from auditing on update', function () {
 });
 
 it('can use a custom context order on creation', function () {
-    Config::set('simple-auditor.context_sort_order', ['id', 'class', 'old', 'new']);
+    Config::set('simple-auditor.context_sort_order', ['id', 'class']);
 
     $this->withoutExceptionHandling();
 
@@ -146,6 +146,115 @@ it('can use a custom context order on creation', function () {
             'name' => 'Test Model',
             'updated_at' => now()->toDateTimeString(),
             'created_at' => now()->toDateTimeString(),
+        ]);
+});
+
+it('can handle unspecified keys in the sort order when creating', function () {
+    Config::set('simple-auditor.context_sort_order', ['id', 'class', 'created_at']);
+
+    $this->withoutExceptionHandling();
+
+    TestModel::create(['name' => 'Test Model']);
+
+    expect(AuditLog::first())
+        ->toBeInstanceOf(AuditLog::class)
+        ->context->toBe([
+            'id' => 1,
+            'class' => 'Motomedialab\SimpleLaravelAudit\Tests\Stubs\TestModel',
+            'created_at' => now()->toDateTimeString(),
+            'name' => 'Test Model',
+            'updated_at' => now()->toDateTimeString(),
+        ]);
+});
+
+// handling invalid arguments when creating
+it('can use default order if empty array is supplied when creating', function () {
+    Config::set('simple-auditor.context_sort_order', []);
+
+    $this->withoutExceptionHandling();
+
+    TestModel::create(['name' => 'Test Model']);
+
+    expect(AuditLog::first())
+        ->toBeInstanceOf(AuditLog::class)
+        ->context->toBe([
+            'name' => 'Test Model',
+            'updated_at' => now()->toDateTimeString(),
+            'created_at' => now()->toDateTimeString(),
+            'id' => 1,
+            'class' => 'Motomedialab\SimpleLaravelAudit\Tests\Stubs\TestModel',
+        ]);
+});
+
+it('can use default order if an incorrect array structure is supplied when creating', function () {
+    Config::set('simple-auditor.context_sort_order', ['key1' => 'value1', 'key2' => 'value2']);
+
+    $this->withoutExceptionHandling();
+
+    TestModel::create(['name' => 'Test Model']);
+
+    expect(AuditLog::first())
+        ->toBeInstanceOf(AuditLog::class)
+        ->context->toBe([
+            'name' => 'Test Model',
+            'updated_at' => now()->toDateTimeString(),
+            'created_at' => now()->toDateTimeString(),
+            'id' => 1,
+            'class' => 'Motomedialab\SimpleLaravelAudit\Tests\Stubs\TestModel',
+        ]);
+});
+
+it('can use default order if a string is supplied when creating', function () {
+    Config::set('simple-auditor.context_sort_order', 'a string');
+
+    $this->withoutExceptionHandling();
+
+    TestModel::create(['name' => 'Test Model']);
+
+    expect(AuditLog::first())
+        ->toBeInstanceOf(AuditLog::class)
+        ->context->toBe([
+            'name' => 'Test Model',
+            'updated_at' => now()->toDateTimeString(),
+            'created_at' => now()->toDateTimeString(),
+            'id' => 1,
+            'class' => 'Motomedialab\SimpleLaravelAudit\Tests\Stubs\TestModel',
+        ]);
+});
+
+it('can use default order if an integer is supplied when creating', function () {
+    Config::set('simple-auditor.context_sort_order', 0);
+
+    $this->withoutExceptionHandling();
+
+    TestModel::create(['name' => 'Test Model']);
+
+    expect(AuditLog::first())
+        ->toBeInstanceOf(AuditLog::class)
+        ->context->toBe([
+            'name' => 'Test Model',
+            'updated_at' => now()->toDateTimeString(),
+            'created_at' => now()->toDateTimeString(),
+            'id' => 1,
+            'class' => 'Motomedialab\SimpleLaravelAudit\Tests\Stubs\TestModel',
+        ]);
+});
+
+it('can use default order if a boolean is supplied when creating', function () {
+    Config::set('simple-auditor.context_sort_order', true);
+
+    $this->withoutExceptionHandling();
+
+    TestModel::create(['name' => 'Test Model']);
+
+    expect(AuditLog::first())
+        ->toBeInstanceOf(AuditLog::class)
+        ->context->toBe([
+            'name' => 'Test Model',
+            'updated_at' => now()->toDateTimeString(),
+            'created_at' => now()->toDateTimeString(),
+            'id' => 1,
+            'class' => 'Motomedialab\SimpleLaravelAudit\Tests\Stubs\TestModel',
         ]);
 });
 
@@ -168,7 +277,28 @@ it('can use a reversed context order on creation', function () {
 });
 
 it('can use a custom context order when updating', function () {
-    Config::set('simple-auditor.context_sort_order', ['id', 'class', 'old', 'new']);
+    Config::set('simple-auditor.context_sort_order', ['id', 'class', 'new', 'old']);
+
+    $model = Model::withoutEvents(fn () => TestModel::create(['name' => 'Test Model']));
+
+    $model->update(['name' => 'Updated Model']);
+
+    expect(AuditLog::first())
+        ->toBeInstanceOf(AuditLog::class)
+        ->context->toBe([
+            'id' => 1,
+            'class' => 'Motomedialab\SimpleLaravelAudit\Tests\Stubs\TestModel',
+            'new' => [
+                'name' => 'Updated Model',
+            ],
+            'old' => [
+                'name' => 'Test Model',
+            ],
+        ]);
+});
+
+it('can handle unspecified keys in the sort order when updating', function () {
+    Config::set('simple-auditor.context_sort_order', ['id', 'class']);
 
     $model = Model::withoutEvents(fn () => TestModel::create(['name' => 'Test Model']));
 
@@ -206,5 +336,111 @@ it('can use a reversed context order when updating', function () {
             'old' => [
                 'name' => 'Test Model',
             ],
+        ]);
+});
+
+// handling invalid arguments when updating
+it('can use default order if empty array is supplied when updating', function () {
+    Config::set('simple-auditor.context_sort_order', []);
+
+    $model = Model::withoutEvents(fn () => TestModel::create(['name' => 'Test Model']));
+
+    $model->update(['name' => 'Updated Model']);
+
+    expect(AuditLog::first())
+        ->toBeInstanceOf(AuditLog::class)
+        ->context->toBe([
+            'old' => [
+                'name' => 'Test Model',
+            ],
+            'new' => [
+                'name' => 'Updated Model',
+            ],
+            'class' => 'Motomedialab\SimpleLaravelAudit\Tests\Stubs\TestModel',
+            'id' => 1,
+        ]);
+});
+
+it('can use default order if an incorrect array structure is supplied when updating', function () {
+    Config::set('simple-auditor.context_sort_order', ['key1' => 'value1', 'key2' => 'value2']);
+
+    $model = Model::withoutEvents(fn () => TestModel::create(['name' => 'Test Model']));
+
+    $model->update(['name' => 'Updated Model']);
+
+    expect(AuditLog::first())
+        ->toBeInstanceOf(AuditLog::class)
+        ->context->toBe([
+            'old' => [
+                'name' => 'Test Model',
+            ],
+            'new' => [
+                'name' => 'Updated Model',
+            ],
+            'class' => 'Motomedialab\SimpleLaravelAudit\Tests\Stubs\TestModel',
+            'id' => 1,
+        ]);
+});
+
+it('can use default order if a string is supplied when updating', function () {
+    Config::set('simple-auditor.context_sort_order', 'a string');
+
+    $model = Model::withoutEvents(fn () => TestModel::create(['name' => 'Test Model']));
+
+    $model->update(['name' => 'Updated Model']);
+
+    expect(AuditLog::first())
+        ->toBeInstanceOf(AuditLog::class)
+        ->context->toBe([
+            'old' => [
+                'name' => 'Test Model',
+            ],
+            'new' => [
+                'name' => 'Updated Model',
+            ],
+            'class' => 'Motomedialab\SimpleLaravelAudit\Tests\Stubs\TestModel',
+            'id' => 1,
+        ]);
+});
+
+it('can use default order if an integer is supplied when updating', function () {
+    Config::set('simple-auditor.context_sort_order', 0);
+
+    $model = Model::withoutEvents(fn () => TestModel::create(['name' => 'Test Model']));
+
+    $model->update(['name' => 'Updated Model']);
+
+    expect(AuditLog::first())
+        ->toBeInstanceOf(AuditLog::class)
+        ->context->toBe([
+            'old' => [
+                'name' => 'Test Model',
+            ],
+            'new' => [
+                'name' => 'Updated Model',
+            ],
+            'class' => 'Motomedialab\SimpleLaravelAudit\Tests\Stubs\TestModel',
+            'id' => 1,
+        ]);
+});
+
+it('can use default order if a boolean is supplied when updating', function () {
+    Config::set('simple-auditor.context_sort_order', true);
+
+    $model = Model::withoutEvents(fn () => TestModel::create(['name' => 'Test Model']));
+
+    $model->update(['name' => 'Updated Model']);
+
+    expect(AuditLog::first())
+        ->toBeInstanceOf(AuditLog::class)
+        ->context->toBe([
+            'old' => [
+                'name' => 'Test Model',
+            ],
+            'new' => [
+                'name' => 'Updated Model',
+            ],
+            'class' => 'Motomedialab\SimpleLaravelAudit\Tests\Stubs\TestModel',
+            'id' => 1,
         ]);
 });

--- a/tests/Feature/ModelObserverTest.php
+++ b/tests/Feature/ModelObserverTest.php
@@ -318,6 +318,27 @@ it('can handle unspecified keys in the sort order when updating', function () {
         ]);
 });
 
+it('can handle extra undefined keys in the sort order when updating', function () {
+    Config::set('simple-auditor.context_sort_order', ['id', 'class', 'new', 'old', 'foo', 'bar']);
+
+    $model = Model::withoutEvents(fn () => TestModel::create(['name' => 'Test Model']));
+
+    $model->update(['name' => 'Updated Model']);
+
+    expect(AuditLog::first())
+        ->toBeInstanceOf(AuditLog::class)
+        ->context->toBe([
+            'id' => 1,
+            'class' => 'Motomedialab\SimpleLaravelAudit\Tests\Stubs\TestModel',
+            'new' => [
+                'name' => 'Updated Model',
+            ],
+            'old' => [
+                'name' => 'Test Model',
+            ],
+        ]);
+});
+
 it('can use a reversed context order when updating', function () {
     Config::set('simple-auditor.context_sort_order', 'reverse');
 

--- a/tests/Feature/ModelObserverTest.php
+++ b/tests/Feature/ModelObserverTest.php
@@ -130,3 +130,81 @@ it('excludes multiple defined columns from auditing on update', function () {
         ->context->new->not->toHaveKey('email_address')
         ->context->new->not->toHaveKey('phone_number');
 });
+
+it('can use a custom context order on creation', function () {
+    Config::set('simple-auditor.context_sort_order', ['id', 'class', 'old', 'new']);
+
+    $this->withoutExceptionHandling();
+
+    TestModel::create(['name' => 'Test Model']);
+
+    expect(AuditLog::first())
+        ->toBeInstanceOf(AuditLog::class)
+        ->context->toBe([
+            'id' => 1,
+            'class' => 'Motomedialab\SimpleLaravelAudit\Tests\Stubs\TestModel',
+            'name' => 'Test Model',
+            'updated_at' => now()->toDateTimeString(),
+            'created_at' => now()->toDateTimeString(),
+        ]);
+});
+
+it('can use a reversed context order on creation', function () {
+    Config::set('simple-auditor.context_sort_order', 'reverse');
+
+    $this->withoutExceptionHandling();
+
+    TestModel::create(['name' => 'Test Model']);
+
+    expect(AuditLog::first())
+        ->toBeInstanceOf(AuditLog::class)
+        ->context->toBe([
+            'class' => 'Motomedialab\SimpleLaravelAudit\Tests\Stubs\TestModel',
+            'id' => 1,
+            'created_at' => now()->toDateTimeString(),
+            'updated_at' => now()->toDateTimeString(),
+            'name' => 'Test Model',
+        ]);
+});
+
+it('can use a custom context order when updating', function () {
+    Config::set('simple-auditor.context_sort_order', ['id', 'class', 'old', 'new']);
+
+    $model = Model::withoutEvents(fn () => TestModel::create(['name' => 'Test Model']));
+
+    $model->update(['name' => 'Updated Model']);
+
+    expect(AuditLog::first())
+        ->toBeInstanceOf(AuditLog::class)
+        ->context->toBe([
+            'id' => 1,
+            'class' => 'Motomedialab\SimpleLaravelAudit\Tests\Stubs\TestModel',
+            'old' => [
+                'name' => 'Test Model',
+            ],
+            'new' => [
+                'name' => 'Updated Model',
+            ],
+        ]);
+});
+
+it('can use a reversed context order when updating', function () {
+    Config::set('simple-auditor.context_sort_order', 'reverse');
+
+    $model = Model::withoutEvents(fn () => TestModel::create(['name' => 'Test Model']));
+
+    $model->update(['name' => 'Updated Model']);
+
+    expect(AuditLog::first())
+        ->toBeInstanceOf(AuditLog::class)
+        ->context->toBe([
+            'id' => 1,
+            'class' => 'Motomedialab\SimpleLaravelAudit\Tests\Stubs\TestModel',
+            'new' => [
+                'name' => 'Updated Model',
+            ],
+            'old' => [
+                'name' => 'Test Model',
+            ],
+        ]);
+});

--- a/tests/Feature/PruneJobTest.php
+++ b/tests/Feature/PruneJobTest.php
@@ -7,7 +7,6 @@ use Motomedialab\SimpleLaravelAudit\Jobs\PruneAuditLogs;
 use Motomedialab\SimpleLaravelAudit\Models\AuditLog;
 
 it('will prune old audit logs', function () {
-
     Config::set('simple-auditor.retain_logs_for_days', 60);
 
     Carbon::setTestNow(now()->subDays(100));

--- a/tests/Unit/FetchObfuscatedIpAddressTest.php
+++ b/tests/Unit/FetchObfuscatedIpAddressTest.php
@@ -7,7 +7,6 @@ use Motomedialab\SimpleLaravelAudit\Tests\TestCase;
 uses(TestCase::class);
 
 it('can obfuscate an ipv4 address', function () {
-
     // spoof an IPv4 address
 
     app()->bind('request', fn () => new Request(server: ['REMOTE_ADDR' => '81.146.11.42']));
@@ -18,7 +17,6 @@ it('can obfuscate an ipv4 address', function () {
 });
 
 it('can obfuscate an ipv6 address', function () {
-
     // spoof an IPv6 address
     app()->bind('request', fn () => new Request(server: ['REMOTE_ADDR' => '2001:db8:85a3::8a2e:370:7334']));
 


### PR DESCRIPTION
An additional config option to allow custom sorting of the context data ordering, and some whitespace cleanups.

The use case I encountered is when I was looking through the table to find the specific model ID, since it was after context data such as `old` & `new` it was difficult to look down the column and find the ID at a glance.

The implementation is intended to be additional rather than modifying, with existing installations and base configurations unaffected. 

The user can either leave the default order as is, reverse it completely, or specify a preferred order for the data such as `['id', 'class', 'old', 'new']`. It will also handle partial ordering, for example if only `['id', 'class']` are supplied then the remaining items will be filled in using the default order.

I have updated the README slightly & added tests for correct functionality as well as accounting for incorrect config value types  - feedback & suggestions for improvements very welcome!